### PR TITLE
Add bundler version to gemfile to make using a gemset easier

### DIFF
--- a/.ruby-version
+++ b/.ruby-version
@@ -1,0 +1,1 @@
+2.2.3@nested_forms

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
 source 'https://rubygems.org'
+
+gem 'bundler', '1.11.2'
 gem 'rails', '4.2.5.1'
 gem 'sqlite3'
 gem 'sass-rails', '~> 5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bundler (= 1.11.2)
   byebug
   coffee-rails (~> 4.1.0)
   jbuilder (~> 2.0)


### PR DESCRIPTION
Bundler version should be in the gemfile so others bundling use the right one
