### PR TITLE
Pks/make address nest in contacts

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -15,7 +15,7 @@ class ContactsController < ApplicationController
   # GET /contacts/new
   def new
     @contact = Contact.new
-    #@contact.addresses.build
+    @contact.addresses.build
   end
 
   # GET /contacts/1/edit
@@ -71,6 +71,6 @@ class ContactsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def contact_params
-      params.require(:contact).permit(:name, addresses_attributes: [:id, :name, :_destroy])
+      params.require(:contact).permit(:name, addresses_attributes: [:id, :address1, :address2, :zip])
     end
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,10 +1,3 @@
 class Address < ActiveRecord::Base
   belongs_to :contact
-  validates :name, presence: true
-
-	def to_s
-		name
-	end
-
-
 end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,9 +1,7 @@
 class Contact < ActiveRecord::Base
 	has_many :addresses, dependent: :destroy
-	accepts_nested_attributes_for :addresses
-	#	reject_if: proc{ |attributes| attributes['name'].blank?},
-	#	allow_destroy: true
-	#validates :name, presence: true
+	accepts_nested_attributes_for :addresses, allow_destroy: true
+	validates :name, presence: true
 
 	def to_s
 		name

--- a/app/views/contacts/_form.html.erb
+++ b/app/views/contacts/_form.html.erb
@@ -1,35 +1,38 @@
 <%= form_for(@contact) do |f| %>
   <% if @contact.errors.any? %>
     <div id="error_explanation">
-        <h2><%= pluralize(@contact.errors.count, "error") %> prohibited this contact from being saved:</h2>
+      <h2><%= pluralize(@contact.errors.count, "error") %> prohibited this contact from being saved:</h2>
 
-        <ul>
-        <% @contact.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-        </ul>
-      </div>
-    <% end %>
-
-    <div class="field">
-      
-      <%= f.label :name %><br>
-      <%= f.text_field :name %>
-      
-      <p>Addresses</p>
-      <%= f.fields_for :addresses do |addresses_form| %>
-            <!--
-            <%#= addresses_form.label :name %>
-            <%#= addresses_form.text_field :name %>
-            -->
-            <%= addresses_form.label :address1 %>
-            <%= addresses_form.text_field :address1 %>
-       <% end %>
+      <ul>
+      <% @contact.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
     </div>
-  <div>
-         
-      
+  <% end %>
+
+  <h3>Contact</h3>
+  <div class="field">
+    <%= f.label :name %><br>
+    <%= f.text_field :name %>
   </div>
+
+  <h3>Address</h3>
+  <%= f.fields_for :addresses do |addresses_form| %>
+    <div class="field">
+      <%= addresses_form.label :address1 %><br>
+      <%= addresses_form.text_field :address1 %>
+    </div>
+    <div class="field">
+      <%= addresses_form.label :address2 %><br>
+      <%= addresses_form.text_field :address2 %>
+    </div>
+    <div class="field">
+      <%= addresses_form.label :zip %><br>
+      <%= addresses_form.number_field :zip %>
+    </div>
+  <% end %>
+
   <div class="actions">
     <%= f.submit %>
   </div>

--- a/app/views/contacts/show.html.erb
+++ b/app/views/contacts/show.html.erb
@@ -3,21 +3,20 @@
 <p>
   <strong>Name:</strong>
   <%= @contact.name %>
-  <!--  Nested Form Begin -->
-  <p>Addresses</p>
-    @contact.addresses Details<br>
-    <%= @contact.addresses.inspect %><br>
-    <p></p>@Contract Details<br>
-    <%= @contact.inspect %><br>
-    <p></p>@address1<br>
-    <%= @address1.inspect %>
-	    
-	    <% if @contact.addresses.any? %>
-		    <%= @contact.addressses.each do |addresses_form| %>
-		    <%= link_to addresses, addresses %>
-		    <% end %>
-  		<% end %>
+  <!--  -->
+
 </p>
 
-<%= link_to 'Show', @contact %> |
+<!-- Nested Form begin -->
+	<% if @contact.addresses.any? %>
+		<%= @contact.addresses.each do |addy| %>
+		<%= link_to :addresses, addy %>
+		<% end %>
+	<% else %>
+	<p>None Available</p>
+	<% end %>
+
+
+
+<%= link_to 'Edit', edit_contact_path(@contact) %> |
 <%= link_to 'Back', contacts_path %>


### PR DESCRIPTION
Fixes Nested address form

A lot of stuff was wrong here and I assume most of it was copy pasta

There were cases where address was validating existence of a property name which address didn't own so that was causes child records to not be created.

Also entities for nested models must be built attached to their parent Contact so the form will display

``` erb
<% form_for
```

will not display anything unless the echo `=` is used in the erb string

``` erb
<%= form_for
```

Also the white list params were associated with the wrong model
